### PR TITLE
feat: suppress npm install output

### DIFF
--- a/src/lib/npm.js
+++ b/src/lib/npm.js
@@ -6,7 +6,7 @@ module.exports = {
     return JSON.parse(data);
   },
   buildInstallCommand: (name, path) => {
-    return 'npm install'
+    return 'npm install>out 2>error'
       .concat(' --no-package-lock --silent')
       .concat(` --prefix ${path}`)
       .concat(` ${name}`);


### PR DESCRIPTION
Redirecting stdout and stderr to files because it cancels
npcheck feature of showing the custom results the console.

More details here:
https://github.com/nodeshift/npcheck/issues/15