### PR TITLE
Handling the NPM output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "npcheck",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npcheck",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "A tool to run various checks on npm modules",
   "keywords": [],
   "author": "Red Hat, Inc.",

--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+const path = require('path');
 const chalk = require('chalk');
 
 const stringBuilder = (text) => ({
@@ -25,14 +27,17 @@ const printStatuses = (statuses) => {
   });
 };
 
-const printWarning = (message) => {
-  console.log(chalk.yellow(message));
+const createErrorLog = (output) => {
+  const now = new Date();
+  const filepath = path.join(process.cwd(), 'npcheck-errors.log');
+  const log = `----\n${now}\n----\n${output.trim()}\n`;
+  fs.appendFileSync(filepath, log);
 };
 
 module.exports = {
   stringBuilder,
   printStatuses,
-  printWarning,
+  createErrorLog,
   success,
   failure,
   warning

--- a/src/lib/npm.js
+++ b/src/lib/npm.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   buildInstallCommand: (name, path) => {
     return 'npm install'
-      .concat(' --no-package-lock --silent')
+      .concat(' --no-package-lock')
       .concat(` --prefix ${path}`)
       .concat(` ${name}`);
   }

--- a/src/plugins/maintenance.js
+++ b/src/plugins/maintenance.js
@@ -1,7 +1,7 @@
 const R = require('ramda');
 const { differenceInDays, formatDistanceToNow } = require('date-fns');
 const { passThroughError } = require('../lib/result');
-const { stringBuilder, printWarning, success, warning } = require('../lib/format');
+const { stringBuilder, success, warning } = require('../lib/format');
 const { fetchGithub } = require('../lib/fetch');
 
 const SIX_MONTHS = 183; // in days
@@ -11,7 +11,9 @@ const maintenancePlugin = async (module, _, options) => {
     .split('github.com/')[1]
     .replace('.git', '');
 
-  const output = stringBuilder('\nChecking maintenance metrics').withPadding(66);
+  const output = stringBuilder('\nChecking maintenance metrics').withPadding(
+    66
+  );
 
   const releases = await fetchGithub(
     `/repos/${githubTarget}/releases`,
@@ -31,9 +33,8 @@ const maintenancePlugin = async (module, _, options) => {
 
   if (difference > SIX_MONTHS) {
     warning(output.get());
-    const reason =
-      `The latest release of "${module.name}" was ${formatDistanceToNow(releaseDate)} ago`;
-    printWarning(`\n${reason}`);
+    const distance = formatDistanceToNow(releaseDate);
+    const reason = `The latest release of "${module.name}" was ${distance} ago`;
     return passThroughError(reason);
   }
 


### PR DESCRIPTION
This PR tries to solve #22 #20 

- When everything goes well npcheck will output a custom message: `deasync@0.1.21 has been installed.`

- When something goes wrong with the NPM installation the cli will output `Failed to download module`, will skip the rest of the checks and will pipe the NPM output to `npcheck-errors.log`

Tested with node 15.x, node 16.x, npm 6.x and npm 7.x 