### PR TITLE
Adding license rules to top-level modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "npcheck",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npcheck",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "A tool to run various checks on npm modules",
   "keywords": [],
   "author": "Red Hat, Inc.",

--- a/src/plugins/license.js
+++ b/src/plugins/license.js
@@ -1,21 +1,41 @@
-const { stringBuilder, success, failure } = require('../lib/format');
-const { error } = require('../lib/result');
+const { stringBuilder, success, failure, warning } = require('../lib/format');
+const { error, passThroughError } = require('../lib/result');
+const { matchLicenses } = require('../lib/regex');
 
 const licensePlugin = async (module, config) => {
+  // Licenses that we'll consider passing
   const licenses = config.licenses?.allow || [];
-  const isLicenseAllowed = licenses.find((name) => name === module?.license);
+  const licensesLocal = config.licenses?.rules[module.name]?.allow || [];
+
+  // Licenses that will pass but with a warning
+  const licensesForcePass = config.licenses?.rules[module.name]?.override || [];
+
+  const isPassing = [...licenses, ...licensesLocal].find((name) =>
+    matchLicenses(module.license, name)
+  );
 
   const output = stringBuilder('\nChecking top-level license').withPadding(66);
 
-  if (!isLicenseAllowed) {
-    failure(output.get());
-    return error(
-      `The module "${module.name}" is under the non-acceptable license "${module.license}".`
+  if (isPassing) {
+    success(output.get());
+    return null;
+  }
+
+  const isForcePassing = licensesForcePass.find((name) =>
+    matchLicenses(module.license, name)
+  );
+
+  if (isForcePassing) {
+    warning(output.get());
+    return passThroughError(
+      `The module "${module.name}" is under the the yet undetermined license "${module.license}". (Manual review needed)`
     );
   }
 
-  success(output.get());
-  return null;
+  failure(output.get());
+  return error(
+    `The module "${module.name}" is under the non-acceptable license "${module.license}".`
+  );
 };
 
 module.exports = licensePlugin;


### PR DESCRIPTION
This PR enables the license rules to apply also to the top-level modules (aka the modules that the ref-arch suggests)