### PR TITLE
Refactoring

### DIFF
--- a/src/lib/result.js
+++ b/src/lib/result.js
@@ -1,9 +1,9 @@
 module.exports = {
-  error: (reason) => ({
+  createError: (reason) => ({
     type: 'error',
     reason
   }),
-  passThroughError: (reason) => ({
+  createWarning: (reason) => ({
     type: 'warning',
     reason
   }),

--- a/src/plugins/archive.js
+++ b/src/plugins/archive.js
@@ -1,4 +1,4 @@
-const { error } = require('../lib/result');
+const { createError } = require('../lib/result');
 const { stringBuilder, success, failure } = require('../lib/format');
 const { fetchGithub } = require('../lib/fetch');
 
@@ -15,7 +15,7 @@ const archivePlugin = async (pkg, _, options) => {
 
   if (repo.deprecated) {
     failure(output.get());
-    return error(
+    return createError(
       `The repository of the "${pkg.name}" module seems to be archived. (https://www.github.com/${githubTarget})`
     );
   }

--- a/src/plugins/deprecation.js
+++ b/src/plugins/deprecation.js
@@ -1,4 +1,4 @@
-const { error } = require('../lib/result');
+const { createError } = require('../lib/result');
 const { stringBuilder, success, failure } = require('../lib/format');
 
 const deprecationPlugin = async (pkg) => {
@@ -10,7 +10,7 @@ const deprecationPlugin = async (pkg) => {
 
   if (isDeprecated) {
     failure(output.get());
-    return error(
+    return createError(
       `Package '${pkg.name}' seems to be deprecated on NPM. (https://npmjs.com/package/${pkg.name})`
     );
   }

--- a/src/plugins/license.js
+++ b/src/plugins/license.js
@@ -1,5 +1,5 @@
 const { stringBuilder, success, failure, warning } = require('../lib/format');
-const { error, passThroughError } = require('../lib/result');
+const { createError, createWarning } = require('../lib/result');
 const { matchLicenses } = require('../lib/regex');
 
 const licensePlugin = async (pkg, config) => {
@@ -27,13 +27,13 @@ const licensePlugin = async (pkg, config) => {
 
   if (isForcePassing) {
     warning(output.get());
-    return passThroughError(
+    return createWarning(
       `The module "${pkg.name}" is under the the yet undetermined license "${pkg.license}". (Manual review needed)`
     );
   }
 
   failure(output.get());
-  return error(
+  return createError(
     `The module "${pkg.name}" is under the non-acceptable license "${pkg.license}".`
   );
 };

--- a/src/plugins/licenseTree.js
+++ b/src/plugins/licenseTree.js
@@ -3,7 +3,7 @@ const util = require('util');
 const chalk = require('chalk');
 const checker = require('license-checker');
 
-const { error, passThroughError } = require('../lib/result');
+const { createError, createWarning } = require('../lib/result');
 const { matchLicenses } = require('../lib/regex');
 const { stringBuilder, success, warning, failure } = require('../lib/format');
 
@@ -49,7 +49,7 @@ const licenseTreePlugin = async (pkg, config) => {
     if (isForcePassing) {
       warning(output.get());
       results.push(
-        passThroughError(
+        createWarning(
           `The module "${pkg.name}" depends on the "${key}" package which is under the yet undetermined license "${value.licenses}". (Manual review needed)`
         )
       );
@@ -59,7 +59,7 @@ const licenseTreePlugin = async (pkg, config) => {
     // Nothing is accepted treat license as an error
     failure(output.get());
     results.push(
-      error(
+      createError(
         `The module "${pkg.name}" depends on the "${key}" package which is under the non-acceptable license "${value.licenses}".`
       )
     );

--- a/src/plugins/maintenance.js
+++ b/src/plugins/maintenance.js
@@ -1,6 +1,6 @@
 const R = require('ramda');
 const { differenceInDays, formatDistanceToNow } = require('date-fns');
-const { passThroughError } = require('../lib/result');
+const { createWarning } = require('../lib/result');
 const { stringBuilder, success, warning } = require('../lib/format');
 const { fetchGithub } = require('../lib/fetch');
 
@@ -23,7 +23,7 @@ const maintenancePlugin = async (pkg, _, options) => {
 
   if (!latestRelease) {
     warning(output.get());
-    return passThroughError(`No releases found for the ${pkg.name} module`);
+    return createWarning(`No releases found for the ${pkg.name} module`);
   }
 
   const now = new Date();
@@ -35,7 +35,7 @@ const maintenancePlugin = async (pkg, _, options) => {
     warning(output.get());
     const distance = formatDistanceToNow(releaseDate);
     const reason = `The latest release of "${pkg.name}" was ${distance} ago`;
-    return passThroughError(reason);
+    return createWarning(reason);
   }
 
   success(output.get());

--- a/src/plugins/support.js
+++ b/src/plugins/support.js
@@ -4,7 +4,7 @@ const pkgSupport = require('@pkgjs/support');
 const nv = require('@pkgjs/nv');
 
 const { stringBuilder, warning, success } = require('../lib/format');
-const { passThroughError } = require('../lib/result');
+const { createWarning } = require('../lib/result');
 
 const supportPlugin = async (pkg) => {
   // Support plugin output
@@ -49,7 +49,7 @@ const supportPlugin = async (pkg) => {
   // LTS support not found :(
   const unsupportedVersions = unsupported.join(', ');
   warning(output.get());
-  return passThroughError(
+  return createWarning(
     `The module "${pkg.name}" appears to have no support for the LTS version(s) ${unsupportedVersions} of Node.js.`
   );
 };

--- a/src/plugins/tests.js
+++ b/src/plugins/tests.js
@@ -1,5 +1,5 @@
 const R = require('ramda');
-const { passThroughError } = require('../lib/result');
+const { createWarning } = require('../lib/result');
 const { fetchGithub } = require('../lib/fetch');
 const {
   stringBuilder,
@@ -63,7 +63,7 @@ const testsPlugin = async (pkg, _, options) => {
 
   warning(testOutput.get());
   printStatuses(statuses);
-  return passThroughError(
+  return createWarning(
     `The "${pkg.name}" seems that is lacking appropriate testing (https://www.github.com/${githubTarget})`
   );
 };


### PR DESCRIPTION
While writing some unit tests I realized that the names `error` and `passThroughError` are bad name choices for the work they're doing. 

So this PR renames the `error` to `createError` and `passThroughError` to `createWarning`. Now I believe it makes more sense for someone looking at the code.