### PR TITLE
License field defined as an array

### DIFF
--- a/src/plugins/license.js
+++ b/src/plugins/license.js
@@ -10,8 +10,13 @@ const licensePlugin = async (pkg, config) => {
   // Licenses that will pass but with a warning
   const licensesForcePass = config.licenses?.rules[pkg.name]?.override || [];
 
+  // We need to check if the the license is defined as a string or an array
+  const license = Array.isArray(pkg.licenses)
+    ? pkg.licenses.map((v) => v.type).join(',')
+    : pkg.license;
+
   const isPassing = [...licenses, ...licensesLocal].find((name) =>
-    matchLicenses(pkg.license, name)
+    matchLicenses(license, name)
   );
 
   const output = stringBuilder('\nChecking top-level license').withPadding(66);
@@ -22,19 +27,19 @@ const licensePlugin = async (pkg, config) => {
   }
 
   const isForcePassing = licensesForcePass.find((name) =>
-    matchLicenses(pkg.license, name)
+    matchLicenses(license, name)
   );
 
   if (isForcePassing) {
     warning(output.get());
     return createWarning(
-      `The module "${pkg.name}" is under the yet undetermined license "${pkg.license}". (Manual review needed)`
+      `The module "${pkg.name}" is under the yet undetermined license(s) "${license}". (Manual review needed)`
     );
   }
 
   failure(output.get());
   return createError(
-    `The module "${pkg.name}" is under the non-acceptable license "${pkg.license}".`
+    `The module "${pkg.name}" is under the non-acceptable license(s) "${license}".`
   );
 };
 

--- a/test/plugins/license.test.js
+++ b/test/plugins/license.test.js
@@ -35,6 +35,32 @@ it('should return null when license is globally accepted', async () => {
   expect(success).toHaveBeenCalled();
 });
 
+it('should handle the case where the license field is an array', async () => {
+  // create a sample env with some dummy data
+  const testEnv = {
+    pkg: {
+      name: 'test',
+      licenses: [
+        {
+          type: 'MIT',
+          url: 'https://raw.github.com/test/test/master/licence'
+        }
+      ]
+    },
+    config: {
+      licenses: {
+        allow: ['MIT', 'Apache-2.0'],
+        rules: {}
+      }
+    }
+  };
+
+  const result = await licensePlugin(testEnv.pkg, testEnv.config);
+
+  expect(result).toBe(null);
+  expect(success).toHaveBeenCalled();
+});
+
 it('should return null when the license is locally accepted', async () => {
   // create a sample env with some dummy data
   const testEnv = {


### PR DESCRIPTION
This PR solves the following issue when the package license is defined as an array instead of a string.

![Screenshot 2021-07-08 at 11 23 06 AM](https://user-images.githubusercontent.com/16292585/124902532-aeecdf80-dfeb-11eb-8229-a398accce06b.png)
