### PR TITLE
fix: clean up env directory after failure

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -86,6 +86,9 @@ module.exports = {
           )
         );
 
+        // clean-up env directory from the current package
+        cleanEnvDirectory();
+
         // continue to the next module on the list
         continue;
       }


### PR DESCRIPTION
If a module fails to install, clean up the env directory before
attempting the next module.