### PR TITLE
fix: return response data for cache hits

### DIFF
--- a/src/lib/network.js
+++ b/src/lib/network.js
@@ -10,7 +10,7 @@ const fetch = async (url) => {
 
 const fetchGithub = async (target, token, override = false) => {
   // check if we already have the response in cache
-  if (cache.has(target)) return cache.get(target);
+  if (cache.has(target)) return cache.get(target).data;
 
   const github = 'https://api.github.com';
   const url = override ? target : `${github}${target}`;

--- a/test/lib/fetch.test.js
+++ b/test/lib/fetch.test.js
@@ -76,8 +76,9 @@ it('should use the cache on requests with the same target', async () => {
     };
   });
 
-  await network.fetchGithub('https://sample.com/test/test');
-  await network.fetchGithub('https://sample.com/test/test');
+  const content1 = await network.fetchGithub('https://sample.com/test/test');
+  const content2 = await network.fetchGithub('https://sample.com/test/test');
 
   expect(axios.get).toHaveBeenCalledTimes(1);
+  expect(content2).toBe(content1);
 });


### PR DESCRIPTION
Return only the response data on cache hits for consistency with
non-cache hits.