### PR TITLE
Typings plugin unit tests

### DIFF
--- a/src/lib/network.js
+++ b/src/lib/network.js
@@ -4,7 +4,13 @@ const cache = new Map();
 const clearCache = () => cache.clear();
 
 const fetch = async (url) => {
+  // check if we already have the response in cache
+  if (cache.has(url)) return cache.get(url).data;
+
   const response = await axios.get(url);
+
+  // save response in cache for future usage
+  cache.set(url, response);
   return response.data;
 };
 

--- a/src/plugins/typings.js
+++ b/src/plugins/typings.js
@@ -9,7 +9,7 @@ const unmangle = (name) => {
   return name.replace('__', '/').replace('@', '');
 };
 
-const typingsPlugin = async (pkg) => {
+const typingsPlugin = async (pkg, _, options) => {
   // Typings plugin output
   const output = stringBuilder('\nChecking for TypeScript typings').withPadding(
     66
@@ -26,7 +26,7 @@ const typingsPlugin = async (pkg) => {
     'https://typespublisher.blob.core.windows.net/typespublisher/data/search-index-min.json';
 
   // We don't want to pull Microsoft's list for every module
-  if (cache === null) {
+  if (cache === null || options.ignore_cache) {
     const response = await fetch(TYPES_URI);
     cache = response;
   }
@@ -46,3 +46,5 @@ const typingsPlugin = async (pkg) => {
 };
 
 module.exports = typingsPlugin;
+
+module.exports.unmangle = unmangle; // exporting unmangle util function for testing purposes

--- a/src/plugins/typings.js
+++ b/src/plugins/typings.js
@@ -2,14 +2,12 @@ const { fetch } = require('../lib/network');
 const { stringBuilder, warning, success } = require('../lib/format');
 const { createWarning } = require('../lib/result');
 
-let cache = null;
-
 // helper function when parsing @types/<package> list
 const unmangle = (name) => {
   return name.replace('__', '/').replace('@', '');
 };
 
-const typingsPlugin = async (pkg, _, options) => {
+const typingsPlugin = async (pkg) => {
   // Typings plugin output
   const output = stringBuilder('\nChecking for TypeScript typings').withPadding(
     66
@@ -25,13 +23,8 @@ const typingsPlugin = async (pkg, _, options) => {
   const TYPES_URI =
     'https://typespublisher.blob.core.windows.net/typespublisher/data/search-index-min.json';
 
-  // We don't want to pull Microsoft's list for every module
-  if (cache === null || options.ignore_cache) {
-    const response = await fetch(TYPES_URI);
-    cache = response;
-  }
-
-  const hasTypesPackage = cache.find((item) => unmangle(item.t) === pkg.name);
+  const data = await fetch(TYPES_URI);
+  const hasTypesPackage = data.find((item) => unmangle(item.t) === pkg.name);
 
   if (hasTypesPackage) {
     success(output.get());

--- a/test/plugins/archive.test.js
+++ b/test/plugins/archive.test.js
@@ -98,10 +98,8 @@ it('should log failure message when module is archived', async () => {
 });
 
 it('should log warning message when module does not specify its GitHub repository url', async () => {
-
   const pkg = {
-    repository: {
-    }
+    repository: {}
   };
 
   const result = await archivePlugin(pkg, null, {});
@@ -111,7 +109,6 @@ it('should log warning message when module does not specify its GitHub repositor
 });
 
 it('should log warning message when module does not specify its GitHub repository', async () => {
-
   const pkg = {};
   const result = await archivePlugin(pkg, null, {});
 

--- a/test/plugins/typings.test.js
+++ b/test/plugins/typings.test.js
@@ -4,7 +4,11 @@ const network = require('../../src/lib/network');
 const typingsPlugin = require('../../src/plugins/typings');
 const { success, warning } = require('../../src/lib/format');
 
-jest.mock('../../src/lib/network');
+jest.mock('../../src/lib/network', () => ({
+  ...jest.requireActual('../../src/lib/network'),
+  fetch: jest.fn()
+}));
+
 jest.mock('../../src/lib/format', () => ({
   ...jest.requireActual('../../src/lib/format'),
   failure: jest.fn(),
@@ -33,6 +37,8 @@ it('should return null if the package specifies typings info on package.json', a
 });
 
 it('should return null if the package has typescript typings through definitely-typed', async () => {
+  // clear network cache before test
+  network.clearCache();
   // mocking http request to GitHub
   network.fetch.mockImplementation(() => {
     return Promise.resolve([
@@ -48,13 +54,15 @@ it('should return null if the package has typescript typings through definitely-
   });
 
   const pkg = { name: 'npcheck' };
-  const result = await typingsPlugin(pkg, {}, { ignore_cache: true });
+  const result = await typingsPlugin(pkg);
 
   expect(result).toBe(null);
   expect(success).toHaveBeenCalled();
 });
 
 it('should return null if the package has typescript typings through definitely-typed', async () => {
+  // clear network cache before test
+  network.clearCache();
   // mocking http request to GitHub
   network.fetch.mockImplementation(() => {
     return Promise.resolve([
@@ -70,20 +78,22 @@ it('should return null if the package has typescript typings through definitely-
   });
 
   const pkg = { name: 'nodeshift/npcheck' };
-  const result = await typingsPlugin(pkg, {}, { ignore_cache: true });
+  const result = await typingsPlugin(pkg);
 
   expect(result).toBe(null);
   expect(success).toHaveBeenCalled();
 });
 
 it('should return a warning when the module has no typescript typings', async () => {
+  // clear network cache before test
+  network.clearCache();
   // mocking http request to GitHub
   network.fetch.mockImplementation(() => {
     return Promise.resolve([]);
   });
 
   const pkg = { name: 'nodeshift/npcheck' };
-  const result = await typingsPlugin(pkg, {}, { ignore_cache: true });
+  const result = await typingsPlugin(pkg);
 
   expect(result.type).toBe('warning');
   expect(warning).toHaveBeenCalled();

--- a/test/plugins/typings.test.js
+++ b/test/plugins/typings.test.js
@@ -16,7 +16,7 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-it('should return null if the package specifies typings info on package.json', async () => {
+it('should return null if the package specifies types info on package.json', async () => {
   const pkg = { name: 'test', types: 'types/index.d.ts' };
   const result = await typingsPlugin(pkg);
 

--- a/test/plugins/typings.test.js
+++ b/test/plugins/typings.test.js
@@ -1,0 +1,99 @@
+/* eslint-env jest */
+
+const network = require('../../src/lib/network');
+const typingsPlugin = require('../../src/plugins/typings');
+const { success, warning } = require('../../src/lib/format');
+
+jest.mock('../../src/lib/network');
+jest.mock('../../src/lib/format', () => ({
+  ...jest.requireActual('../../src/lib/format'),
+  failure: jest.fn(),
+  success: jest.fn(),
+  warning: jest.fn()
+}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+it('should return null if the package specifies typings info on package.json', async () => {
+  const pkg = { name: 'test', types: 'types/index.d.ts' };
+  const result = await typingsPlugin(pkg);
+
+  expect(result).toBe(null);
+  expect(success).toHaveBeenCalled();
+});
+
+it('should return null if the package specifies typings info on package.json', async () => {
+  const pkg = { name: 'test', typings: 'types/index.d.ts' };
+  const result = await typingsPlugin(pkg);
+
+  expect(result).toBe(null);
+  expect(success).toHaveBeenCalled();
+});
+
+it('should return null if the package has typescript typings through definitely-typed', async () => {
+  // mocking http request to GitHub
+  network.fetch.mockImplementation(() => {
+    return Promise.resolve([
+      {
+        p: 'https://github.com/nodeshift/npcheck',
+        l: 'npcheck',
+        g: [],
+        t: 'npcheck', // <-- we're interested in this field
+        m: ['npcheck'],
+        d: 211011042
+      }
+    ]);
+  });
+
+  const pkg = { name: 'npcheck' };
+  const result = await typingsPlugin(pkg, {}, { ignore_cache: true });
+
+  expect(result).toBe(null);
+  expect(success).toHaveBeenCalled();
+});
+
+it('should return null if the package has typescript typings through definitely-typed', async () => {
+  // mocking http request to GitHub
+  network.fetch.mockImplementation(() => {
+    return Promise.resolve([
+      {
+        p: 'https://github.com/nodeshift/npcheck',
+        l: '@nodeshift/npcheck',
+        g: [],
+        t: 'nodeshift__npcheck', // <-- we're interested in this field
+        m: ['nodeshift__npcheck'],
+        d: 211011042
+      }
+    ]);
+  });
+
+  const pkg = { name: 'nodeshift/npcheck' };
+  const result = await typingsPlugin(pkg, {}, { ignore_cache: true });
+
+  expect(result).toBe(null);
+  expect(success).toHaveBeenCalled();
+});
+
+it('should return a warning when the module has no typescript typings', async () => {
+  // mocking http request to GitHub
+  network.fetch.mockImplementation(() => {
+    return Promise.resolve([]);
+  });
+
+  const pkg = { name: 'nodeshift/npcheck' };
+  const result = await typingsPlugin(pkg, {}, { ignore_cache: true });
+
+  expect(result.type).toBe('warning');
+  expect(warning).toHaveBeenCalled();
+});
+
+it("should parse the definitely-typed objects from the Microsoft's list", async () => {
+  const { unmangle } = typingsPlugin;
+
+  expect(unmangle('npcheck')).toBe('npcheck');
+  expect(unmangle('nodeshift__npcheck')).toBe('nodeshift/npcheck');
+  expect(unmangle('@npcheck')).toBe('npcheck');
+  expect(unmangle('@nodeshift__npcheck')).toBe('nodeshift/npcheck');
+});


### PR DESCRIPTION
I also introduced the `ignore_cache` boolean option only to be used with unit tests since declaring the cache at the top (https://github.com/nodeshift/npcheck/blob/main/src/plugins/typings.js#L5) works fine when running the npcheck CLI but completely breaks the unit tests.