### PR TITLE
chore: removes unused broken script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "pretest": "eslint --ignore-path .gitignore",
     "lint:fix": "eslint . --fix",
     "test": "jest --no-colors",
-    "coverage": "jest --coverage",
+    "coverage": "jest --coverage --no-colors",
     "release": "standard-version"
   },
   "dependencies": {


### PR DESCRIPTION
We are using --no-colors to make the test pass by avoiding
colors to make interference related to PASS FAIL output.

Since we transferred the coverage bits to coveralls action
seems like we don't need that script anymore.

Also the script is broken and seems unused since April
https://github.com/nodeshift/npcheck/pull/4