### PR TITLE
enable lint for pretest run script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "start": "node .",
     "prepare": "husky install",
-    "pretest": "eslint --ignore-path .gitignore",
+    "pretest": "eslint --ignore-path .gitignore .",
     "lint:fix": "eslint . --fix",
     "test": "jest --no-colors",
     "coverage": "jest --coverage --no-colors",

--- a/src/plugins/citgm.js
+++ b/src/plugins/citgm.js
@@ -15,12 +15,12 @@ const getCITGMLookup = async (token) => {
   );
   const content = Buffer.from(metadata.content, metadata.encoding);
   return JSON.parse(content);
-}
+};
 
 const citgmPlugin = async (pkg, _, options) => {
   // Support plugin output
   const output = stringBuilder(
-      '\nChecking if module is tested by community CITGM runs'
+    '\nChecking if module is tested by community CITGM runs'
   ).withPadding(66);
 
   const lookup = await getCITGMLookup(options.token);
@@ -39,8 +39,8 @@ const citgmPlugin = async (pkg, _, options) => {
       );
     }
     const lts = (await nv('supported')).map(v => v.version);
-    for (version of lts) {
-      if ((!Array.isArray(skip) && semver.satisfies(version, skip)) || Array.isArray(skip) && skip.some(v => semver.satisfies(version, v))) {
+    for (const version of lts) {
+      if ((!Array.isArray(skip) && semver.satisfies(version, skip)) || (Array.isArray(skip) && skip.some(v => semver.satisfies(version, v)))) {
         warning(output.get());
         return createWarning(
             `The module "${pkg.name}" is not tested (skipped on ${version}) by community CITGM runs.`

--- a/test/plugins/citgm.test.js
+++ b/test/plugins/citgm.test.js
@@ -21,7 +21,7 @@ const mockCITGMLookup = (content, encoding = 'utf8') => {
   network.fetchGithub.mockImplementation(() => {
     return Promise.resolve({ content, encoding });
   });
-}
+};
 
 beforeEach(() => {
   nv.mockImplementation(() => {
@@ -180,7 +180,7 @@ it('should not perform partial matches', async () => {
     name: 'mymodule'
   };
 
-  const result = await citgmPlugin(pkg, null, {});
+  await citgmPlugin(pkg, null, {});
   expect(network.fetchGithub).toHaveBeenCalled();
   expect(network.fetchGithub).toBeCalledWith(CITGM_LOOKUP_URL, undefined);
   expect(format.warning).toHaveBeenCalled();


### PR DESCRIPTION
Currently it does not seem like the eslint run script is checking any
files. This commit adds the current directory to the eslint command
and fixes a few or the lint issues that were reported.