### PR TITLE
add warn message for native modules (NAN, C++)

### DIFF
--- a/src/plugins/support.js
+++ b/src/plugins/support.js
@@ -5,8 +5,9 @@ const nv = require('@pkgjs/nv');
 
 const { stringBuilder, warning, success } = require('../lib/format');
 const { createWarning } = require('../lib/result');
+const { fetchGithub } = require('../lib/network');
 
-const supportPlugin = async (pkg) => {
+const supportPlugin = async (pkg, config, options) => {
   // Support plugin output
   const output = stringBuilder('\nChecking for LTS support').withPadding(66);
 
@@ -52,11 +53,51 @@ const supportPlugin = async (pkg) => {
   // LTS support not found :(
   const unsupportedVersions = unsupported.join(', ');
   warning(output.get());
-  return createWarning(
-    supportData === 'unknown' && engines === '0.0.0'
-      ? `The module "${pkg.name}" does not specify the engines field or package-support.json so we cannot determine if it supports the LTS versions of Node.js.`
-      : `The module "${pkg.name}" has no support for the LTS version(s) ${unsupportedVersions} of Node.js.`
-  );
+
+  const tlsUndetermined = supportData === 'unknown' && engines === '0.0.0';
+  const nonNapiNativeModule = await isNonNapiNativeModule(pkg, options);
+
+  if (tlsUndetermined && nonNapiNativeModule) {
+    return createWarning(`The native module "${pkg.name}" does not use ` +
+      'Node-API and does not specify the engines field or ' +
+      'package-support.json, so we cannot determine if it supports the LTS ' +
+      'versions of Node.js.');
+  }
+
+  if (tlsUndetermined) {
+    return createWarning(`The module "${pkg.name}" does not specify the ` +
+      'engines field or package-support.json, so we cannot determine if it ' +
+      'supports the LTS versions of Node.js.');
+  }
+
+  return createWarning(`The module "${pkg.name}" has no support for the LTS ` +
+    `version(s) ${unsupportedVersions} of Node.js.`);
 };
+
+async function isNonNapiNativeModule (pkg, options) {
+  if (pkg?.repository?.url) {
+    const githubTarget = pkg.repository.url
+      .split('github.com/')[1]
+      .replace('.git', '');
+
+    const commitHistory = await fetchGithub(
+      `/repos/${githubTarget}/commits`,
+      options.githubToken
+    );
+
+    const repoTreeURL = commitHistory[0].commit.tree.url;
+    const repoTree = await fetchGithub(repoTreeURL, options.githubToken, true);
+
+    const bindingGyp = repoTree.tree.find(
+      ({ path, type }) => path.includes('binding.gyp') && type === 'blob'
+    );
+
+    if (bindingGyp) {
+      return true;
+    }
+  }
+
+  return pkg?.dependencies?.nan;
+}
 
 module.exports = supportPlugin;

--- a/test/plugins/support.test.js
+++ b/test/plugins/support.test.js
@@ -258,6 +258,7 @@ it("should not return a N-API warning if the package doesn't have support for LT
 
   const result = await supportPlugin(pkg, {}, { githubToken: 'dummyToken' });
 
+  expect(result.reason).toContain('native');
   expect(result.reason).not.toContain('Node-API');
   expect(result.type).toBe('warning');
   expect(warning).toHaveBeenCalled();

--- a/test/plugins/support.test.js
+++ b/test/plugins/support.test.js
@@ -2,10 +2,12 @@
 
 const pkgSupport = require('@pkgjs/support');
 const nv = require('@pkgjs/nv');
+const network = require('../../src/lib/network');
 
 const supportPlugin = require('../../src/plugins/support');
 const { success, warning } = require('../../src/lib/format');
 
+jest.mock('../../src/lib/network');
 jest.mock('@pkgjs/support');
 jest.mock('@pkgjs/nv');
 jest.mock('../../src/lib/format', () => ({
@@ -145,6 +147,118 @@ it("should return a warning if the package doesn't have support for LTS", async 
 
   const result = await supportPlugin(pkg);
 
+  expect(result.type).toBe('warning');
+  expect(warning).toHaveBeenCalled();
+});
+
+it("should return a N-API warning if the package doesn't have support for LTS and is a C++ addon native module", async () => {
+  // mocking http request to GitHub to get binding.gyp
+  network.fetchGithub.mockImplementationOnce(() => {
+    return Promise.resolve([{
+      commit: { tree: { url: 'dummy-url' } }
+    }]);
+  }).mockImplementationOnce(() => {
+    return Promise.resolve({
+      tree: { find: () => true }
+    });
+  });
+
+  pkgSupport.getSupportData.mockImplementation(() => {
+    return { contents: 'unknown' };
+  });
+
+  const pkg = {
+    name: 'test',
+    repository: {
+      url: 'git+https://github.com/n/n.git'
+    }
+  };
+
+  nv.mockImplementation(() => {
+    return Promise.resolve([{ version: '14.2.20' }, { version: '16.3.19' }]);
+  });
+
+  const result = await supportPlugin(pkg, {}, { githubToken: 'dummyToken' });
+
+  expect(result.reason).toContain('native');
+  expect(result.reason).toContain('Node-API');
+  expect(result.type).toBe('warning');
+  expect(warning).toHaveBeenCalled();
+});
+
+it("should return a N-API warning if the package doesn't have support for LTS and is a NAN native module", async () => {
+  // mocking http request to GitHub with no binding.gyp
+  network.fetchGithub.mockImplementationOnce(() => {
+    return Promise.resolve([{
+      commit: { tree: { url: 'dummy-url' } }
+    }]);
+  }).mockImplementationOnce(() => {
+    return Promise.resolve({
+      tree: { find: () => false }
+    });
+  });
+
+  pkgSupport.getSupportData.mockImplementation(() => {
+    return { contents: 'unknown' };
+  });
+
+  const pkg = {
+    name: 'test',
+    repository: {
+      url: 'git+https://github.com/n/n.git'
+    },
+    dependencies: {
+      lodash: '^4.17.21',
+      nan: '^3.0.0'
+    }
+  };
+
+  nv.mockImplementation(() => {
+    return Promise.resolve([{ version: '14.2.20' }, { version: '16.3.19' }]);
+  });
+
+  const result = await supportPlugin(pkg, {}, { githubToken: 'dummyToken' });
+
+  expect(result.reason).toContain('native');
+  expect(result.reason).toContain('Node-API');
+  expect(result.type).toBe('warning');
+  expect(warning).toHaveBeenCalled();
+});
+
+it("should not return a N-API warning if the package doesn't have support for LTS and is a N-API native module", async () => {
+  // mocking http request to GitHub with no binding.gyp
+  network.fetchGithub.mockImplementationOnce(() => {
+    return Promise.resolve([{
+      commit: { tree: { url: 'dummy-url' } }
+    }]);
+  }).mockImplementationOnce(() => {
+    return Promise.resolve({
+      tree: { find: () => false }
+    });
+  });
+
+  pkgSupport.getSupportData.mockImplementation(() => {
+    return { contents: 'unknown' };
+  });
+
+  const pkg = {
+    name: 'test',
+    repository: {
+      url: 'git+https://github.com/n/n.git'
+    },
+    dependencies: {
+      lodash: '^4.17.21',
+      'node-addon-api': '^3.0.0'
+    }
+  };
+
+  nv.mockImplementation(() => {
+    return Promise.resolve([{ version: '14.2.20' }, { version: '16.3.19' }]);
+  });
+
+  const result = await supportPlugin(pkg, {}, { githubToken: 'dummyToken' });
+
+  expect(result.reason).not.toContain('Node-API');
   expect(result.type).toBe('warning');
   expect(warning).toHaveBeenCalled();
 });


### PR DESCRIPTION
This commit adds a check and an additional warning message for modules
where the LTS version cannot be determined. If the module is a native
module (NAN, or a C++ addon) the warnings message should contain a
message saying that the module is a native module and that it does not
use N-API.