### PR TITLE
add support for citgm skip list

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Npcheck requires a configuration file where custom behavior can be specified. Th
 
 - `licenses.rules[modules].override`: List of licenses that the cli will treat as warnings (future license decisions to be made) but won't break the CI. _(type: Array)_
 
-- `citgm'.skip[modules]`: Modules to be skipped by the CITGM checker _(type: Array)_
+- `citgm.skip[modules]`: Modules to be skipped by the CITGM checker _(type: Array)_
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Npcheck requires a configuration file where custom behavior can be specified. Th
 
 - `licenses.rules[modules].override`: List of licenses that the cli will treat as warnings (future license decisions to be made) but won't break the CI. _(type: Array)_
 
+- `citgm'.skip[modules]`: Modules to be skipped by the CITGM checker _(type: Array)_
+
 ### Example
 
 A simple npcheck configuration file.
@@ -50,6 +52,9 @@ A simple npcheck configuration file.
   "licenses": {
     "allow": ["MIT", "Apache-2.0"],
     "rules": {}
+  },
+  "citgm": {
+    "skip": ["rhea"]
   }
 }
 ```

--- a/src/plugins/citgm.js
+++ b/src/plugins/citgm.js
@@ -17,11 +17,21 @@ const getCITGMLookup = async (token) => {
   return JSON.parse(content);
 };
 
-const citgmPlugin = async (pkg, _, options) => {
+const citgmPlugin = async (pkg, config, options) => {
   // Support plugin output
   const output = stringBuilder(
     '\nChecking if module is tested by community CITGM runs'
   ).withPadding(66);
+
+  // Skip this module if it was specified in the config.citgm.skip list.
+  if (config?.citgm?.skip) {
+    const list = config.citgm.skip;
+    for (const moduleName of list) {
+      if (pkg.name === moduleName) {
+        return null;
+      }
+    }
+  }
 
   const lookup = await getCITGMLookup(options.token);
   if (!lookup[pkg.name]) {

--- a/test/plugins/citgm.test.js
+++ b/test/plugins/citgm.test.js
@@ -186,7 +186,7 @@ it('should not perform partial matches', async () => {
   expect(format.warning).toHaveBeenCalled();
 });
 
-it('should skip module is specified in citgm.skip list', async () => {
+it('should skip module if specified in citgm.skip list', async () => {
   mockCITGMLookup('{ "rhea": {} }');
 
   const pkg = {

--- a/test/plugins/citgm.test.js
+++ b/test/plugins/citgm.test.js
@@ -185,3 +185,22 @@ it('should not perform partial matches', async () => {
   expect(network.fetchGithub).toBeCalledWith(CITGM_LOOKUP_URL, undefined);
   expect(format.warning).toHaveBeenCalled();
 });
+
+it('should skip module is specified in citgm.skip list', async () => {
+  mockCITGMLookup('{ "rhea": {} }');
+
+  const pkg = {
+    name: 'rhea'
+  };
+
+  const config = {
+    citgm: {
+      skip: [pkg.name]
+    }
+  };
+
+  expect(await citgmPlugin(pkg, config, {})).toBeNull();
+  expect(network.fetchGithub).not.toHaveBeenCalled();
+  expect(network.fetchGithub).not.toBeCalledWith(CITGM_LOOKUP_URL, undefined);
+  expect(format.success).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
This commit add support to configure a list of modules that should not
be checked by the CITGM checker. This list could for example include
modules that will never be part of the modules covered by CITGM and
avoids those warnings.