### PR TITLE
chore: add release please for github release automation.

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,14 @@
+on:
+   push:
+     branches:
+       - main
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: node
+          package-name: npcheck


### PR DESCRIPTION
This adds the release please github action, which will create a new PR for releases when commits to the project happen.  The version and generated changelog are based on the commits, so it is important to use the conventional commit formatting.

fixes #76