### PR TITLE
feat: add a check for a default number of dependencies

### DIFF
--- a/src/plugins/resolved.js
+++ b/src/plugins/resolved.js
@@ -1,12 +1,21 @@
 const Arborist = require('@npmcli/arborist');
-const { createError } = require('../lib/result');
+const { createError, createWarning } = require('../lib/result');
 const isGitURL = require('is-git-url');
+
+const NUM_OF_DEPS = 20;
 
 const resolvedPlugin = async (pkg, config, options, path = './npcheck-env') => {
   const results = [];
   const arborist = new Arborist({ path: path });
   const result = await arborist.loadActual();
   const children = result.children;
+  if (children.size - 1 > NUM_OF_DEPS) { // minus 1, the module itself
+    results.push(
+      createWarning(
+        `The module "${pkg.name}" has more dependencies (including sub-dependencies) than the default "${NUM_OF_DEPS}".`
+      )
+    );
+  }
   children.forEach(c => {
     const resolved = c.resolved.toString();
     if (isGitURL(resolved)) {


### PR DESCRIPTION
Example output:

```
(1): The module "a-foo-module" does not specify the engines field or package-support.json, so we cannot determine if it supports the LTS versions of Node.js.
(2): The module "a-foo-module" seems to have no available TypeScript typings.
(3): The module "a-foo-module" is not tested by community CITGM runs.
(4): The module "a-foo-module" has more dependencies (including sub-dependencies) than the default "1".  <---- 
```

Related to #84 

We are using 20 as default for now according with the issue created