### PR TITLE
fix: remove caching on network post

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4053,6 +4053,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/eslint-plugin-standard": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
+      "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
+      "deprecated": "standard 16.0.0 and eslint-config-standard 16.0.0 no longer require the eslint-plugin-standard package. You can remove it from your dependencies with 'npm rm eslint-plugin-standard'. More info here: https://github.com/standard/standard/issues/1316",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "dev": true,
@@ -13432,6 +13457,14 @@
     "eslint-plugin-promise": {
       "version": "4.3.1",
       "dev": true
+    },
+    "eslint-plugin-standard": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
+      "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
+      "dev": true,
+      "peer": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/src/lib/network.js
+++ b/src/lib/network.js
@@ -32,13 +32,8 @@ const fetchGithub = async (target, token, override = false) => {
 };
 
 const post = async (url, options = {}) => {
-  // check if we already have the response in cache
-  if (cache.has(url)) return cache.get(url).data;
-
+  // don't cache since the options need to be considered
   const response = await axios.post(url, options.body, options);
-
-  // save response in cache for future usage
-  cache.set(url, response);
   return response.data;
 };
 

--- a/src/lib/regex.js
+++ b/src/lib/regex.js
@@ -4,6 +4,9 @@ const escapeRegExp = (string) => {
 
 // 'MIT OR Apache.2.0'.match('MIT')
 const matchLicenses = (license, target) => {
+  // allow BSD* to match BSD
+  if (license === 'BSD*') license = 'BSD';
+
   const filter = new RegExp(`\\b${escapeRegExp(target)}\\b`);
   const match = Array.isArray(license)
     ? license.join(' OR ').match(filter)


### PR DESCRIPTION
post was only used by audit plugin. Since
post was used with same graphql url but options
to specify the query any cached value would
result in incorrect result from previous query.
Remove caching so that we get the right answer
for each request.

Signed-off-by: Michael Dawson <mdawson@devrus.com>