### PR TITLE
feat!: remove Node 20 support, add Node 26 to CI

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
 
     steps:
     - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Prerequisites
 
-- Node.js - version 22.x or greater
+- Node.js - version 22.x, 24.x, or 26.x
 
 ## Install
 


### PR DESCRIPTION
## Summary

This PR updates the Node.js versions to align with the current active LTS releases.

### Changes:
- **Removed:** Node 20 (no longer in active LTS support)
- **Added:** Node 26 (new LTS version)
- **Retained:** Node 22, Node 24

### Files Updated:
-  - Updated CI matrix from [20.x, 22.x, 24.x] to [22.x, 24.x, 26.x]
-  - Updated release node version from 22 to 26
-  - Updated prerequisites to reflect supported versions (22.x, 24.x, 26.x)
-  - Regenerated via `npm install`

### Breaking Change:
This is a breaking change as Node 20 support is being removed.