### PR TITLE
chore: add Node 24, 26 to engines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "standard-version": "^9.3.2"
       },
       "engines": {
-        "node": ">=22"
+        "node": "^22 || ^24 || ^26"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "npcheck": "index.js"
   },
   "engines": {
-    "node": ">=22"
+    "node": "^22 || ^24 || ^26"
   },
   "type": "commonjs",
   "scripts": {


### PR DESCRIPTION
## Summary

This PR updates the Node.js version support in `npcheck` to align with the current active and maintenance LTS versions.

## Changes

- **Added:** Node.js v24 (active LTS) and v26 (current) to `engines.node` in `package.json`
- **Maintained:** Node.js v22 (maintenance LTS) support
- **Updated:** `engines.node` from `>=22` to `^22 || ^24 || ^26` for explicit version support

## Notes

- CI workflows already correctly test against Node.js 22.x, 24.x, and 26.x
- Release workflow already uses Node.js 24 (latest active LTS)
- `package-lock.json` regenerated with `npm install`
- All tests pass